### PR TITLE
Update access token setting/hints to AppDelegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Mapbox GL for iOS](https://github.com/mapbox/mapbox-gl-native) demo/template 
 1.  Clone or [download](https://github.com/friedbunny/mbgl-ios-demo/archive/master.zip) this repository
 1. Run `pod install` to download the Mapbox GL library via [Cocoapods](https://cocoapods.org)
 1. Open `mbgl-ios-demo.xcworkspace` in Xcode
-1. Insert your [Mapbox access token](https://www.mapbox.com/developers/api/#access-tokens) into Map View’s Attributes Inspector panel in Interface Builder: ![Interface Builder has lots of names for things that you'll never know about](https://cloud.githubusercontent.com/assets/1198851/7786331/4b227e8e-017a-11e5-9b27-bf3428cef7e9.png)
+1. Insert your [Mapbox access token](https://www.mapbox.com/developers/api/#access-tokens) in [`AppDelegate.m`](https://github.com/friedbunny/mbgl-ios-demo/blob/38b640521b65f51234821db8d63478ff2104faff/mbgl-demo-ios/AppDelegate.m#L21)
 1. Build amazing cartographic things
 
 ## Don’t like storyboards?

--- a/mbgl-demo-ios/AppDelegate.m
+++ b/mbgl-demo-ios/AppDelegate.m
@@ -14,8 +14,11 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    // NOTE
-    // Set your Mapbox Access Token via the Storyboard, in the Attributes Inspector panel for Map View
+    // Setting the Mapbox access token can happen in one of several places:
+    //   * AppDelegate (here)
+    //   * Info.plist via the `MGLMapboxAccessToken` key
+    
+    [MGLAccountManager setAccessToken:@"<mapbox-access-token-here>"];
 
     return YES;
 }

--- a/mbgl-demo-ios/ViewController.m
+++ b/mbgl-demo-ios/ViewController.m
@@ -23,7 +23,7 @@
     [super viewDidLoad];
     
     // NOTE
-    // Set your Mapbox Access Token via the Storyboard, in the Attributes Inspector panel for Map View
+    // Set your Mapbox Access Token in AppDelegate.m
     
     // set the map to show and follow the user's location (initially)
     self.mapView.userTrackingMode = MGLUserTrackingModeFollow;


### PR DESCRIPTION
Using storyboards and trying to set the access token in the app delegate doesn't work yet upstream — merge this when it does.
