### PR TITLE
Xcode placeholder token for access token

### DIFF
--- a/mbgl-demo-ios/AppDelegate.m
+++ b/mbgl-demo-ios/AppDelegate.m
@@ -18,7 +18,7 @@
     //   * AppDelegate (here)
     //   * Info.plist via the `MGLMapboxAccessToken` key
     
-    [MGLAccountManager setAccessToken:@"<mapbox-access-token-here>"];
+    [MGLAccountManager setAccessToken:<#mapbox-access-token-here#>];
 
     return YES;
 }

--- a/mbgl-demo-ios/AppDelegate.m
+++ b/mbgl-demo-ios/AppDelegate.m
@@ -18,7 +18,7 @@
     //   * AppDelegate (here)
     //   * Info.plist via the `MGLMapboxAccessToken` key
     
-    [MGLAccountManager setAccessToken:<#mapbox-access-token-here#>];
+    [MGLAccountManager setAccessToken:<#your access token#>];
 
     return YES;
 }


### PR DESCRIPTION
It’s a compiler error until the developer puts in their own access token.

https://github.com/mapbox/mapbox-gl-native/issues/1647#issuecomment-106120120
http://nshipster.com/xcode-snippets/#placeholder-tokens
